### PR TITLE
Initial LollipopSwitcher support (requires root)

### DIFF
--- a/src/com/tobykurien/batteryfu/BatteryFu.java
+++ b/src/com/tobykurien/batteryfu/BatteryFu.java
@@ -23,6 +23,7 @@ import com.tobykurien.batteryfu.data_switcher.APNSwitcher;
 import com.tobykurien.batteryfu.data_switcher.GingerbreadSwitcher;
 import com.tobykurien.batteryfu.data_switcher.ICSSwitcher;
 import com.tobykurien.batteryfu.data_switcher.MobileDataSwitcher;
+import com.tobykurien.batteryfu.data_switcher.LollipopSwitcher;
 
 public class BatteryFu extends PreferenceActivity {
    public static final String LOG_TAG = "BatteryFu";
@@ -208,14 +209,17 @@ public class BatteryFu extends PreferenceActivity {
    }
 
    public static void checkApnDroid(Context context, Settings settings) {
+       Log.d("BatteryFu", "checkApnDroid");
       MobileDataSwitcher switcher = MobileDataSwitcher.getSwitcher(context, settings);
+       Log.d("BatteryFu", "after getSwitcher");
       if (switcher instanceof GingerbreadSwitcher ||
-          switcher instanceof ICSSwitcher) {
+          switcher instanceof ICSSwitcher ||
+          switcher instanceof LollipopSwitcher) {
          // on gingerbread/ICS, we won't worry about ApnDroid
          settings.setUseApnDroid(false);
          return;
       }
-      
+
       if (APNDroidSwitcher.isApnDroidInstalled(context)) {
          if (!settings.isUseApndroid()) {
             // APNDroid installed, use it by default

--- a/src/com/tobykurien/batteryfu/data_switcher/LollipopSwitcher.java
+++ b/src/com/tobykurien/batteryfu/data_switcher/LollipopSwitcher.java
@@ -35,16 +35,16 @@ public class LollipopSwitcher extends MobileDataSwitcher {
             try {
                 p.waitFor();
                 if (p.exitValue() != 255) {
-                    Log.d("BatteryFu", "Enabled Mobile Data");
+                    Log.d("BatteryFu", "LollipopSwitcher: Enabled Mobile Data");
                 }
                 else {
-                    Log.d("BatteryFu", "Error enabling mobile data");
+                    Log.d("BatteryFu", "LollipopSwitcher: Error enabling mobile data");
                 }
             } catch (InterruptedException e) {
-                Log.d("BatteryFu", "Error enabling mobile data");
+                Log.d("BatteryFu", "LollipopSwitcher: Error enabling mobile data");
             }
         } catch (IOException e) {
-            Log.d("BatteryFu", "Error enabling mobile data");
+            Log.d("BatteryFu", "LollipopSwitcher: Error enabling mobile data");
         }
 
     }
@@ -63,16 +63,16 @@ public class LollipopSwitcher extends MobileDataSwitcher {
             try {
                 p.waitFor();
                 if (p.exitValue() != 255) {
-                    Log.d("BatteryFu", "Disabled Mobile Data");
+                    Log.d("BatteryFu", "LollipopSwitcher: Disabled Mobile Data");
                 }
                 else {
-                    Log.d("BatteryFu", "Error disabling mobile data");
+                    Log.d("BatteryFu", "LollipopSwitcher: Error disabling mobile data");
                 }
             } catch (InterruptedException e) {
-                Log.d("BatteryFu", "Error disabling mobile data");
+                Log.d("BatteryFu", "LollipopSwitcher: Error disabling mobile data");
             }
         } catch (IOException e) {
-            Log.d("BatteryFu", "Error disabling mobile data");
+            Log.d("BatteryFu", "LollipopSwitcher: Error disabling mobile data");
         }
     }
 
@@ -97,23 +97,18 @@ public class LollipopSwitcher extends MobileDataSwitcher {
             try {
                 p.waitFor();
                 if (p.exitValue() != 255) {
-                    // TODO Code to run on success
-                    Log.d("BatteryFu", "Successfully got root rights in init!");
+                    Log.d("BatteryFu", "LollipopSwitcher: Successfully got root rights in init!");
                     return true;
                 }
                 else {
-                    // TODO Code to run on unsuccessful
-                    Log.d("BatteryFu", "Error gaining root access");
+                    Log.d("BatteryFu", "LollipopSwitcher: Error gaining root access");
                 }
             } catch (InterruptedException e) {
-                // TODO Code to run in interrupted exception
-                Log.d("BatteryFu", "Error gaining root access");
+                Log.d("BatteryFu", "LollipopSwitcher: Error gaining root access");
             }
         } catch (IOException e) {
-            // TODO Code to run in input/output exception
-            Log.d("BatteryFu", "Error gaining root access");
+            Log.d("BatteryFu", "LollipopSwitcher: Error gaining root access");
         }
-        Log.d("BatteryFu", "return false in init");
         return false;
     }
 

--- a/src/com/tobykurien/batteryfu/data_switcher/LollipopSwitcher.java
+++ b/src/com/tobykurien/batteryfu/data_switcher/LollipopSwitcher.java
@@ -1,0 +1,120 @@
+package com.tobykurien.batteryfu.data_switcher;
+
+import java.lang.Runtime;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.util.Log;
+import android.widget.Toast;
+
+import com.tobykurien.batteryfu.BatteryFu;
+import com.tobykurien.batteryfu.R;
+
+/**
+ * A Lollipop-compatible data switcher
+ * @author andy
+ */
+public class LollipopSwitcher extends MobileDataSwitcher {
+    private ConnectivityManager connMan;
+    private Context context;
+
+    @Override
+    public void enableMobileData(Context context) {
+
+        try {
+            // Preform su to get root priviledges
+            Process p = Runtime.getRuntime().exec("su");
+
+            // Attempt to write a file to a root-only
+            DataOutputStream os = new DataOutputStream(p.getOutputStream());
+            os.writeBytes("svc data enable\n");
+            os.writeBytes("exit\n");
+            os.flush();
+            try {
+                p.waitFor();
+                if (p.exitValue() != 255) {
+                    Log.d("BatteryFu", "Enabled Mobile Data");
+                }
+                else {
+                    Log.d("BatteryFu", "Error enabling mobile data");
+                }
+            } catch (InterruptedException e) {
+                Log.d("BatteryFu", "Error enabling mobile data");
+            }
+        } catch (IOException e) {
+            Log.d("BatteryFu", "Error enabling mobile data");
+        }
+
+    }
+
+    @Override
+    public void disableMobileData(Context context) {
+        try {
+            // Preform su to get root privledges
+            Process p = Runtime.getRuntime().exec("su");
+
+            // Attempt to write a file to a root-only
+            DataOutputStream os = new DataOutputStream(p.getOutputStream());
+            os.writeBytes("svc data disable\n");
+            os.writeBytes("exit\n");
+            os.flush();
+            try {
+                p.waitFor();
+                if (p.exitValue() != 255) {
+                    Log.d("BatteryFu", "Disabled Mobile Data");
+                }
+                else {
+                    Log.d("BatteryFu", "Error disabling mobile data");
+                }
+            } catch (InterruptedException e) {
+                Log.d("BatteryFu", "Error disabling mobile data");
+            }
+        } catch (IOException e) {
+            Log.d("BatteryFu", "Error disabling mobile data");
+        }
+    }
+
+    @Override
+    public int isToggleWorking(Context context) {
+        Log.d("BatteryFu", "isToggleWorking");
+        if(init(context))
+            return 0;
+        else
+            return R.string.apn_problem_text;
+    }
+
+    public boolean init(Context context) {
+        Log.d("BatteryFu", "init in LollipopSwitcher");
+        try {
+            // Perform su to get root priviledges
+            Process p = Runtime.getRuntime().exec("su");
+
+            DataOutputStream os = new DataOutputStream(p.getOutputStream());
+            os.writeBytes("exit\n");
+            os.flush();
+            try {
+                p.waitFor();
+                if (p.exitValue() != 255) {
+                    // TODO Code to run on success
+                    Log.d("BatteryFu", "Successfully got root rights in init!");
+                    return true;
+                }
+                else {
+                    // TODO Code to run on unsuccessful
+                    Log.d("BatteryFu", "Error gaining root access");
+                }
+            } catch (InterruptedException e) {
+                // TODO Code to run in interrupted exception
+                Log.d("BatteryFu", "Error gaining root access");
+            }
+        } catch (IOException e) {
+            // TODO Code to run in input/output exception
+            Log.d("BatteryFu", "Error gaining root access");
+        }
+        Log.d("BatteryFu", "return false in init");
+        return false;
+    }
+
+}

--- a/src/com/tobykurien/batteryfu/data_switcher/MobileDataSwitcher.java
+++ b/src/com/tobykurien/batteryfu/data_switcher/MobileDataSwitcher.java
@@ -12,6 +12,7 @@ public abstract class MobileDataSwitcher {
 	public static MobileDataSwitcher apndroid = new APNDroidSwitcher();
    public static MobileDataSwitcher gb = new GingerbreadSwitcher();
    public static MobileDataSwitcher ics = new ICSSwitcher();
+    public static MobileDataSwitcher lollipop = new LollipopSwitcher();
 	
 	/**
 	 * Get the right mobile data switcher
@@ -19,6 +20,12 @@ public abstract class MobileDataSwitcher {
 	 * @return
 	 */
 	public static MobileDataSwitcher getSwitcher(Context context, Settings settings) {
+        if(Build.VERSION.SDK_INT >= 19) {
+            if(lollipop.isToggleWorking(context) == 0) {
+                //Toast.makeText(context, "Using Lollipop switcher", Toast.LENGTH_LONG).show();
+                return lollipop;
+            }
+        }
       if (Integer.parseInt(Build.VERSION.SDK) >= 14) {
          if (ics.isToggleWorking(context) == 0) {
             //Toast.makeText(context, "Using ICS switcher", Toast.LENGTH_LONG).show();

--- a/src/com/tobykurien/batteryfu/data_switcher/MobileDataSwitcher.java
+++ b/src/com/tobykurien/batteryfu/data_switcher/MobileDataSwitcher.java
@@ -26,14 +26,14 @@ public abstract class MobileDataSwitcher {
                 return lollipop;
             }
         }
-      if (Integer.parseInt(Build.VERSION.SDK) >= 14) {
+      if ((Build.VERSION.SDK_INT >= 14) && (Build.VERSION.SDK_INT < 19)) {
          if (ics.isToggleWorking(context) == 0) {
             //Toast.makeText(context, "Using ICS switcher", Toast.LENGTH_LONG).show();
             return ics;
          }
       }
       
-	   if (Integer.parseInt(Build.VERSION.SDK) >= 9) {
+	   if ((Build.VERSION.SDK_INT >= 9) && (Build.VERSION.SDK_INT < 14)) {
 	      if (gb.isToggleWorking(context) == 0) {
             //Toast.makeText(context, "Using Gingerbread switcher", Toast.LENGTH_LONG).show();
 	         return gb;


### PR DESCRIPTION
This implements initial support for Lollipop. Due to limitations in the API, this currently requires root privileges.