### PR TITLE
Fix version codes to not use LollipopSwitcher on KitKat

### DIFF
--- a/src/com/tobykurien/batteryfu/data_switcher/MobileDataSwitcher.java
+++ b/src/com/tobykurien/batteryfu/data_switcher/MobileDataSwitcher.java
@@ -20,13 +20,13 @@ public abstract class MobileDataSwitcher {
 	 * @return
 	 */
 	public static MobileDataSwitcher getSwitcher(Context context, Settings settings) {
-        if(Build.VERSION.SDK_INT >= 19) {
+        if(Build.VERSION.SDK_INT > 19) {
             if(lollipop.isToggleWorking(context) == 0) {
                 //Toast.makeText(context, "Using Lollipop switcher", Toast.LENGTH_LONG).show();
                 return lollipop;
             }
         }
-      if ((Build.VERSION.SDK_INT >= 14) && (Build.VERSION.SDK_INT < 19)) {
+      if ((Build.VERSION.SDK_INT >= 14) && (Build.VERSION.SDK_INT <= 19)) {
          if (ics.isToggleWorking(context) == 0) {
             //Toast.makeText(context, "Using ICS switcher", Toast.LENGTH_LONG).show();
             return ics;


### PR DESCRIPTION
Previous commits used LollipopSwitcher already on KitKat, thus requiring root access. This fixes the comparison.