### PR TITLE
Fix data sometimes not disconnected on Android >= Kit Kat

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -116,6 +116,8 @@
 
         <service android:name=".ScreenService" >
         </service>
+        <service android:name=".DataService">
+        </service>
     </application>
 
 </manifest>

--- a/Widgets/build.gradle
+++ b/Widgets/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.5.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 
@@ -11,7 +11,7 @@ apply plugin: 'android-library'
 
 android {
     compileSdkVersion 18
-    buildToolsVersion "19"
+    buildToolsVersion "19.1"
 
     dependencies {
       compile fileTree(dir: 'libs', includes: ['*.jar'])

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.5.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 
@@ -14,8 +14,8 @@ task wrapper(type: Wrapper) {
 }
 
 android {
-    compileSdkVersion 18
-    buildToolsVersion "19"
+    compileSdkVersion 20
+    buildToolsVersion "20"
 
 
     dependencies {

--- a/src/com/tobykurien/batteryfu/BatteryFu.java
+++ b/src/com/tobykurien/batteryfu/BatteryFu.java
@@ -12,6 +12,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceActivity;
+import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -37,6 +38,12 @@ public class BatteryFu extends PreferenceActivity {
    public void onCreate(Bundle savedInstanceState) {
       super.onCreate(savedInstanceState);
       Log.i("BatteryFu", "Loading on API level " + android.os.Build.VERSION.SDK);
+
+       PreferenceManager pm = getPreferenceManager();
+       if(Build.VERSION.SDK_INT > Build.VERSION_CODES.HONEYCOMB)
+           pm.setSharedPreferencesMode(MODE_MULTI_PROCESS);
+       pm.setSharedPreferencesName(Settings.PREFS_NAME);
+
 
       // Show the preferences screen
       try {
@@ -209,9 +216,7 @@ public class BatteryFu extends PreferenceActivity {
    }
 
    public static void checkApnDroid(Context context, Settings settings) {
-       Log.d("BatteryFu", "checkApnDroid");
       MobileDataSwitcher switcher = MobileDataSwitcher.getSwitcher(context, settings);
-       Log.d("BatteryFu", "after getSwitcher");
       if (switcher instanceof GingerbreadSwitcher ||
           switcher instanceof ICSSwitcher ||
           switcher instanceof LollipopSwitcher) {
@@ -219,14 +224,14 @@ public class BatteryFu extends PreferenceActivity {
          settings.setUseApnDroid(false);
          return;
       }
-
       if (APNDroidSwitcher.isApnDroidInstalled(context)) {
          if (!settings.isUseApndroid()) {
             // APNDroid installed, use it by default
             settings.setUseApnDroid(true);
          }
       } else {
-         if (settings.isUseApndroid()) settings.setUseApnDroid(false);
+         if (settings.isUseApndroid())
+             settings.setUseApnDroid(false);
       }
    }
 

--- a/src/com/tobykurien/batteryfu/BatteryMinder.java
+++ b/src/com/tobykurien/batteryfu/BatteryMinder.java
@@ -179,17 +179,17 @@ public class BatteryMinder extends ActivityBase {
   }
    
   public static void checkBattery(Context context) {
+     Settings settings = Settings.getSettings(context);
+
      SharedPreferences pref =  PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
      
-     long lastRun = pref.getLong("last_run", 0);
+     long lastRun = settings.getLastRun();
      
      if (System.currentTimeMillis() - lastRun < 1000*60*10) {
         // too soon to check
         return;
      }
-
      
-     
-     pref.edit().putLong("last_run", System.currentTimeMillis()).commit();
+     settings.setLastRun(System.currentTimeMillis());
   }
 }

--- a/src/com/tobykurien/batteryfu/DataService.java
+++ b/src/com/tobykurien/batteryfu/DataService.java
@@ -1,0 +1,141 @@
+package com.tobykurien.batteryfu;
+
+import android.app.IntentService;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.content.Intent;
+import android.net.wifi.WifiManager;
+import android.util.Log;
+
+import com.tobykurien.android.Utils;
+import com.tobykurien.batteryfu.data_switcher.MobileDataSwitcher;
+
+/**
+ * Created by andy on 29/01/15.
+ */
+public class DataService extends IntentService {
+
+    public DataService() {
+        super("DataService working");
+        Log.d("BatteryFu", "Starting DataService to handle command");
+    }
+
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        boolean force = intent.getBooleanExtra("force", false);
+        final Context context = getApplicationContext();
+        final Settings settings = Settings.getSettings(context);
+
+
+        if(intent.getStringExtra("action").equals("disable"))
+        {
+            BatteryFu.checkApnDroid(context, settings);
+            if (!force) {
+                // if (!settings.isDataOn()) {
+                // MainFunctions.showNotification(context, settings,
+                // "DEBUG: Data is already off");
+                // return true;
+                // }
+
+                if (settings.isDataWhileCharging() && settings.isCharging()) {
+                    MainFunctions.showNotification(context, settings, context.getString(R.string.data_switched_on_while_charging));
+                    return;
+                }
+
+                if (settings.isScreenOnKeepData() && ScreenService.isScreenOn(context)) {
+                    // MainFunctions.showNotification(context, settings,
+                    // "Data kept on, waiting for screen to switch off");
+                    settings.setDisconnectOnScreenOff(true);
+                    return;
+                }
+
+                if (settings.isDataWhileScreenOn() && ScreenService.isScreenOn(context)) {
+                    MainFunctions.showNotification(context, settings, context.getString(R.string.data_switched_on_while_screen_is_on));
+                    return;
+                }
+            }
+
+            context.getContentResolver().cancelSync(null);
+
+            // save data state
+            settings.setDataStateOn(false);
+            settings.setSyncOnData(false);
+
+            if (settings.isMobileDataEnabled()) {
+                MobileDataSwitcher.disableMobileData(context, settings);
+            } else {
+                Log.d("BatteryFu", "Mobile data toggling disabled");
+            }
+
+            if (settings.isWifiEnabled()) {
+                WifiManager wm = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
+                wm.disconnect();
+                wm.setWifiEnabled(false);
+            } else {
+                Log.d("BatteryFu", "Wifi toggling disabled");
+            }
+        }
+        else if(intent.getStringExtra("action").equals("enable"))
+        {
+            boolean forceMobile = intent.getBooleanExtra("forceMobile", false);
+            final NotificationManager nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+
+            // wait a bit for wifi to connect, and if not connected, connect mobile data
+            BatteryFu.checkApnDroid(context, settings);
+
+            if (force) {
+                if (Utils.isNetworkConnected(context)) {
+                    // do the sync now
+                    MainFunctions.startSync(context);
+                } else {
+                    // sync once connected
+                    settings.setSyncOnData(true);
+                }
+            }
+
+            if (!settings.isDataOn()) {
+                // save data state
+                settings.setDataStateOn(true);
+
+                // clear any previous notifications
+                //nm.cancel(NOTIFICATION_CONNECTIVITY);
+
+                // enable wifi
+                if (settings.isWifiEnabled() && !settings.isTravelMode()) {
+                    Log.i("BatteryFu", "DataToggler enabling wifi");
+                    final WifiManager wm = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
+                    wm.setWifiEnabled(true);
+                    wm.startScan();
+                    wm.reconnect();
+
+                    if (!forceMobile) {
+                        try {
+                            Thread.sleep(10000); // wait 10 seconds
+                        } catch (InterruptedException e) {
+                        }
+
+                        if (wm.getConnectionInfo() == null || wm.getConnectionInfo().getNetworkId() < 0) {
+                            Log.i("BatteryFu", "Wifi not connected after timeout, enabling mobile data");
+                            connectMobileData(context, settings);
+                        }
+                    } else {
+                        // also connect mobile data
+                        connectMobileData(context, settings);
+                    }
+                } else {
+                    Log.d("BatteryFu", "Wifi toggling disabled");
+                    connectMobileData(context, settings);
+                }
+            }
+        }
+    }
+
+    private static void connectMobileData(final Context context, final Settings settings) {
+        // turn on mobile data
+        if (settings.isMobileDataEnabled()) {
+            MobileDataSwitcher.enableMobileData(context, settings);
+        } else {
+            Log.d("BatteryFu", "Mobile data toggling disabled");
+        }
+    }
+}

--- a/src/com/tobykurien/batteryfu/DataService.java
+++ b/src/com/tobykurien/batteryfu/DataService.java
@@ -23,13 +23,12 @@ public class DataService extends IntentService {
     @Override
     protected void onHandleIntent(Intent intent) {
         boolean force = intent.getBooleanExtra("force", false);
-        final Context context = getApplicationContext();
-        final Settings settings = Settings.getSettings(context);
+        final Settings settings = Settings.getSettings(this);
 
 
         if(intent.getStringExtra("action").equals("disable"))
         {
-            BatteryFu.checkApnDroid(context, settings);
+            BatteryFu.checkApnDroid(this, settings);
             if (!force) {
                 // if (!settings.isDataOn()) {
                 // MainFunctions.showNotification(context, settings,
@@ -38,37 +37,37 @@ public class DataService extends IntentService {
                 // }
 
                 if (settings.isDataWhileCharging() && settings.isCharging()) {
-                    MainFunctions.showNotification(context, settings, context.getString(R.string.data_switched_on_while_charging));
+                    MainFunctions.showNotification(this, settings, this.getString(R.string.data_switched_on_while_charging));
                     return;
                 }
 
-                if (settings.isScreenOnKeepData() && ScreenService.isScreenOn(context)) {
+                if (settings.isScreenOnKeepData() && ScreenService.isScreenOn(this)) {
                     // MainFunctions.showNotification(context, settings,
                     // "Data kept on, waiting for screen to switch off");
                     settings.setDisconnectOnScreenOff(true);
                     return;
                 }
 
-                if (settings.isDataWhileScreenOn() && ScreenService.isScreenOn(context)) {
-                    MainFunctions.showNotification(context, settings, context.getString(R.string.data_switched_on_while_screen_is_on));
+                if (settings.isDataWhileScreenOn() && ScreenService.isScreenOn(this)) {
+                    MainFunctions.showNotification(this, settings, context.getString(R.string.data_switched_on_while_screen_is_on));
                     return;
                 }
             }
 
-            context.getContentResolver().cancelSync(null);
+            this.getContentResolver().cancelSync(null);
 
             // save data state
             settings.setDataStateOn(false);
             settings.setSyncOnData(false);
 
             if (settings.isMobileDataEnabled()) {
-                MobileDataSwitcher.disableMobileData(context, settings);
+                MobileDataSwitcher.disableMobileData(this, settings);
             } else {
                 Log.d("BatteryFu", "Mobile data toggling disabled");
             }
 
             if (settings.isWifiEnabled()) {
-                WifiManager wm = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
+                WifiManager wm = (WifiManager) this.getSystemService(Context.WIFI_SERVICE);
                 wm.disconnect();
                 wm.setWifiEnabled(false);
             } else {
@@ -78,15 +77,15 @@ public class DataService extends IntentService {
         else if(intent.getStringExtra("action").equals("enable"))
         {
             boolean forceMobile = intent.getBooleanExtra("forceMobile", false);
-            final NotificationManager nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+            final NotificationManager nm = (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE);
 
             // wait a bit for wifi to connect, and if not connected, connect mobile data
-            BatteryFu.checkApnDroid(context, settings);
+            BatteryFu.checkApnDroid(this, settings);
 
             if (force) {
-                if (Utils.isNetworkConnected(context)) {
+                if (Utils.isNetworkConnected(this)) {
                     // do the sync now
-                    MainFunctions.startSync(context);
+                    MainFunctions.startSync(this);
                 } else {
                     // sync once connected
                     settings.setSyncOnData(true);
@@ -103,7 +102,7 @@ public class DataService extends IntentService {
                 // enable wifi
                 if (settings.isWifiEnabled() && !settings.isTravelMode()) {
                     Log.i("BatteryFu", "DataToggler enabling wifi");
-                    final WifiManager wm = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
+                    final WifiManager wm = (WifiManager) this.getSystemService(Context.WIFI_SERVICE);
                     wm.setWifiEnabled(true);
                     wm.startScan();
                     wm.reconnect();
@@ -116,15 +115,15 @@ public class DataService extends IntentService {
 
                         if (wm.getConnectionInfo() == null || wm.getConnectionInfo().getNetworkId() < 0) {
                             Log.i("BatteryFu", "Wifi not connected after timeout, enabling mobile data");
-                            connectMobileData(context, settings);
+                            connectMobileData(this, settings);
                         }
                     } else {
                         // also connect mobile data
-                        connectMobileData(context, settings);
+                        connectMobileData(this, settings);
                     }
                 } else {
                     Log.d("BatteryFu", "Wifi toggling disabled");
-                    connectMobileData(context, settings);
+                    connectMobileData(this, settings);
                 }
             }
         }

--- a/src/com/tobykurien/batteryfu/DataService.java
+++ b/src/com/tobykurien/batteryfu/DataService.java
@@ -49,7 +49,7 @@ public class DataService extends IntentService {
                 }
 
                 if (settings.isDataWhileScreenOn() && ScreenService.isScreenOn(this)) {
-                    MainFunctions.showNotification(this, settings, context.getString(R.string.data_switched_on_while_screen_is_on));
+                    MainFunctions.showNotification(this, settings, this.getString(R.string.data_switched_on_while_screen_is_on));
                     return;
                 }
             }
@@ -101,7 +101,7 @@ public class DataService extends IntentService {
 
                 // enable wifi
                 if (settings.isWifiEnabled() && !settings.isTravelMode()) {
-                    Log.i("BatteryFu", "DataToggler enabling wifi");
+                    Log.i("BatteryFu", "DataToggler enabling WiFi");
                     final WifiManager wm = (WifiManager) this.getSystemService(Context.WIFI_SERVICE);
                     wm.setWifiEnabled(true);
                     wm.startScan();

--- a/src/com/tobykurien/batteryfu/DataService.java
+++ b/src/com/tobykurien/batteryfu/DataService.java
@@ -84,6 +84,7 @@ public class DataService extends IntentService {
                     MainFunctions.showNotification(this, settings, getString(R.string.data_disabled_offline_mode_activated));
                     break;
                 case NOTIFICATION_TYPE_WAITING_FOR_SYNC:
+                    MainFunctions.showNotificationWaitingForSync(this, settings);
                     break;
                 case NOTIFICATION_TYPE_NONE:
                     break;

--- a/src/com/tobykurien/batteryfu/DataService.java
+++ b/src/com/tobykurien/batteryfu/DataService.java
@@ -20,10 +20,15 @@ public class DataService extends IntentService {
         Log.d("BatteryFu", "Starting DataService to handle command");
     }
 
+    public static final int NOTIFICATION_TYPE_NONE = 0;
+    public static final int NOTIFICATION_TYPE_OFFLINE_MODE = 1;
+    public static final int NOTIFICATION_TYPE_WAITING_FOR_SYNC = 2;
+
     @Override
     protected void onHandleIntent(Intent intent) {
         boolean force = intent.getBooleanExtra("force", false);
         final Settings settings = Settings.getSettings(this);
+        final int notificationType = intent.getIntExtra("notificationType", NOTIFICATION_TYPE_NONE);
 
 
         if(intent.getStringExtra("action").equals("disable"))
@@ -72,6 +77,16 @@ public class DataService extends IntentService {
                 wm.setWifiEnabled(false);
             } else {
                 Log.d("BatteryFu", "Wifi toggling disabled");
+            }
+            switch(notificationType)
+            {
+                case NOTIFICATION_TYPE_OFFLINE_MODE:
+                    MainFunctions.showNotification(this, settings, getString(R.string.data_disabled_offline_mode_activated));
+                    break;
+                case NOTIFICATION_TYPE_WAITING_FOR_SYNC:
+                    break;
+                case NOTIFICATION_TYPE_NONE:
+                    break;
             }
         }
         else if(intent.getStringExtra("action").equals("enable"))

--- a/src/com/tobykurien/batteryfu/DataToggler.java
+++ b/src/com/tobykurien/batteryfu/DataToggler.java
@@ -1,21 +1,17 @@
 package com.tobykurien.batteryfu;
 
 import android.app.AlarmManager;
-import android.app.NotificationManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.net.wifi.WifiManager;
-import android.os.AsyncTask;
 import android.os.Build;
 import android.util.Log;
 import android.widget.Toast;
 
-import com.tobykurien.android.Utils;
 import com.tobykurien.batteryfu.compat.Api17;
 import com.tobykurien.batteryfu.compat.Api3;
-import com.tobykurien.batteryfu.data_switcher.MobileDataSwitcher;
 
 public class DataToggler extends BroadcastReceiver {
    public static final int NOTIFICATION_CONNECTIVITY = 1;

--- a/src/com/tobykurien/batteryfu/DataToggler.java
+++ b/src/com/tobykurien/batteryfu/DataToggler.java
@@ -60,9 +60,7 @@ public class DataToggler extends BroadcastReceiver {
          } else if ("data://sleep".equals(intent.getDataString()) || "data://sleep_once".equals(intent.getDataString())
                   || "data://off".equals(intent.getDataString())) {
             Log.d("BatteryFu", "Data disable");
-            if (disableData(context, false)) {
-               MainFunctions.showNotificationWaitingForSync(context, settings);
-            }
+            disableData(context, false, DataService.NOTIFICATION_TYPE_WAITING_FOR_SYNC);
          } else if ("nightmode://on".equals(intent.getDataString())) {
             Log.d("BatteryFu", "Night mode enable");
             if (!settings.isNightmode()) {
@@ -106,9 +104,7 @@ public class DataToggler extends BroadcastReceiver {
          } else if ("offlinemode://on".equals(intent.getDataString())) {
             Log.d("BatteryFu", "Offline mode enable");
             MainFunctions.teardownDataAlarms(context, null);
-            if (disableData(context, true)) {
-               MainFunctions.showNotification(context, settings, context.getString(R.string.data_disabled_offline_mode_activated));
-            }
+            disableData(context, true, DataService.NOTIFICATION_TYPE_OFFLINE_MODE);
          } else if ("onlinemode://on".equals(intent.getDataString())) {
             Log.d("BatteryFu", "Online mode enable");
             MainFunctions.teardownDataAlarms(context, null);
@@ -192,25 +188,25 @@ public class DataToggler extends BroadcastReceiver {
       return false;
    }
 
-   /**
-    * Ensure that the screen service is running
-    * 
-    * @param context
-    * @param pref
-    */
    static void ensureScreenService(Context context) {
       // start the service for screen on
       Intent srvInt = new Intent(context, ScreenService.class);
       context.startService(srvInt);
    }
 
+    static boolean disableData(final Context context, boolean force)
+    {
+        return disableData(context, force, DataService.NOTIFICATION_TYPE_NONE);
+    }
+
    // Disable wifi and mobile data
-   static boolean disableData(final Context context, boolean force) {
+   static boolean disableData(final Context context, boolean force, final int notificationType) {
       Log.i("BatteryFu", "DataToggler disabling data");
 
        Intent intent = new Intent(context, DataService.class);
        intent.putExtra("action", "disable");
        intent.putExtra("force", force);
+       intent.putExtra("notificationType", notificationType);
        context.startService(intent);
 
       return true;

--- a/src/com/tobykurien/batteryfu/ModeSelect.java
+++ b/src/com/tobykurien/batteryfu/ModeSelect.java
@@ -69,7 +69,10 @@ public class ModeSelect extends Activity {
             } else if (isNightmodeOff(mode)) {
                i.setData(Uri.parse("nightmode://off"));               
             } else if (isSync(mode)) {
-               i.setData(Uri.parse("data://on"));               
+               i.setData(Uri.parse("data://on"));
+                Settings settings = Settings.getSettings(ModeSelect.this);
+                if(settings.isScreenOnKeepData())
+                    settings.setDisconnectOnScreenOff(true);
             } else if (mode.equals(getString(R.string.settings))) {
                showSettings();
                return;

--- a/src/com/tobykurien/batteryfu/ScreenService.java
+++ b/src/com/tobykurien/batteryfu/ScreenService.java
@@ -8,6 +8,9 @@ import android.content.SharedPreferences;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
 import android.util.Log;
+import android.os.Build;
+import com.tobykurien.batteryfu.compat.Api7;
+import com.tobykurien.batteryfu.compat.Api20;
 
 public class ScreenService extends Service {
 	private GeneralReceiver generalReceiver;
@@ -30,7 +33,7 @@ public class ScreenService extends Service {
         filter.addAction(Intent.ACTION_USER_PRESENT);
         generalReceiver = new GeneralReceiver();
         setScreenOn(getApplicationContext(), true);
-        registerReceiver(generalReceiver, filter);		
+        registerReceiver(generalReceiver, filter);
 	}
 	
 	@Override
@@ -41,21 +44,28 @@ public class ScreenService extends Service {
 			unregisterReceiver(generalReceiver);
 		} catch (Exception e) {			
 		}
-
 		super.onDestroy();
 	}
 
 	public static boolean isScreenOn(Context context) {
-		SharedPreferences pref = PreferenceManager
-		.getDefaultSharedPreferences(context);
-		return pref.getBoolean("screen_state_on", false);
-		
-		//return screenOn;
+        boolean ret;
+        if(Build.VERSION.SDK_INT >= 20)
+        {
+            ret = Api20.isScreenOn(context);
+        }
+        else if(Build.VERSION.SDK_INT >= 7)
+        {
+            ret = Api7.isScreenOn(context);
+        }
+        else {
+            Settings settings = Settings.getSettings(context);
+            ret = settings.getScreenOnOff();
+        }
+        return ret;
 	}
 
 	public static void setScreenOn(Context context, boolean screenOn) {
-		SharedPreferences pref = PreferenceManager
-		.getDefaultSharedPreferences(context);
-		pref.edit().putBoolean("screen_state_on", screenOn).commit();
+        Settings settings = Settings.getSettings(context);
+        settings.setScreenOnOff(screenOn);
 	}
 }

--- a/src/com/tobykurien/batteryfu/Settings.java
+++ b/src/com/tobykurien/batteryfu/Settings.java
@@ -1,13 +1,8 @@
 package com.tobykurien.batteryfu;
 
-import java.util.HashMap;
-
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
-import android.preference.PreferenceManager;
-import android.util.Log;
-import android.widget.Toast;
 
 public class Settings {
 	public static boolean DEBUG_NIGHT_MODE = false;
@@ -21,51 +16,54 @@ public class Settings {
 	public static int FIRST_RUN_VERSION = 2;
     public static final String PREFS_NAME = "com.tobykurien.BatteryFu.shared_prefs";
 
-	private SharedPreferences mPref;
     private static Settings mInstance;
+    private Context mContext;
 
-	private Settings(SharedPreferences preferences) {
-		mPref = preferences;
-	}
+	private Settings(Context context) {
+        mContext = context.getApplicationContext();
+    }
+    
+    private synchronized SharedPreferences getPreferences()
+    {
+        SharedPreferences preferences;
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB)
+        {
+            preferences = mContext.getSharedPreferences(PREFS_NAME, Context.MODE_MULTI_PROCESS);
+        }
+        else
+        {
+            preferences = mContext.getSharedPreferences(PREFS_NAME, 0);
+        }
+        return preferences;  
+    }
 
 	public static synchronized Settings getSettings(Context context) {
         if(mInstance == null)
         {
-            SharedPreferences preferences;
-            Context ctx = context.getApplicationContext();
-            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB)
-            {
-                preferences = ctx.getSharedPreferences(PREFS_NAME, 0 | Context.MODE_MULTI_PROCESS);
-            }
-            else
-            {
-                preferences = ctx.getSharedPreferences(PREFS_NAME, 0);
-            }
-            mInstance = new Settings(preferences);
+            mInstance = new Settings(context);
         }
-
       return mInstance;
 	}
 	
 	public boolean isDnsFix() {
-		return mPref.getBoolean("dns_fix", false);		
+		return getPreferences().getBoolean("dns_fix", false);		
 	}
 
    public void setIsDnsFix(boolean dnsFix) {
-      mPref.edit().putBoolean("dns_fix", dnsFix).commit();
+      getPreferences().edit().putBoolean("dns_fix", dnsFix).commit();
    }
 	
 	public boolean isEnabled() {
-		return mPref.getBoolean("enabled", false);
+        return getPreferences().getBoolean("enabled", false);
 	}
 
    public boolean isForceSync() {
-      return mPref.getBoolean("force_sync", true);
+      return getPreferences().getBoolean("force_sync", true);
    }
 	
    public boolean isNightmodeOnly() {
       if (!isNightmodeEnabled()) return false;
-      return mPref.getBoolean("night_mode_only", false);
+      return getPreferences().getBoolean("night_mode_only", false);
    }
 
    public String getNightmodeStart() {
@@ -73,160 +71,160 @@ public class Settings {
 	}
 
 	public String getNightmodeStart(String defaultVal) {
-		return mPref.getString("night_mode_start", defaultVal);
+		return getPreferences().getString("night_mode_start", defaultVal);
 	}	
 	
 	public String getNightmodeEnd() {
-		return mPref.getString("night_mode_end", Settings.DEFAULT_NIGHT_MODE_END);
+		return getPreferences().getString("night_mode_end", Settings.DEFAULT_NIGHT_MODE_END);
 	}
 	
 	public boolean isDataWhileScreenOn() {
-		return mPref.getBoolean("screen_on_data", false);
+		return getPreferences().getBoolean("screen_on_data", false);
 	}
 
 	public boolean isScreenOnKeepData() {
-      return mPref.getBoolean("screen_keep_data", true);
+      return getPreferences().getBoolean("screen_keep_data", true);
    }
 
 	public boolean isMobileDataEnabled() {
-		return mPref.getBoolean("mobile", false);
+		return getPreferences().getBoolean("mobile", false);
 	}
 
 	public boolean isDataWhileCharging() {
-		return mPref.getBoolean("charger_on_data", false);
+		return getPreferences().getBoolean("charger_on_data", false);
 	}
 	
 	public boolean isNightmodeEnabled() {
-		return mPref.getBoolean("night_mode_enabled", false);
+		return getPreferences().getBoolean("night_mode_enabled", false);
 	}
 
 	public boolean isWifiEnabled() {
-		return mPref.getBoolean("wifi", true);
+		return getPreferences().getBoolean("wifi", true);
 	}
 
 	public String getScreenOffDelayTime() {
-		return mPref.getString("screen_off_sleep_time", "30");
+		return getPreferences().getString("screen_off_sleep_time", "30");
 	}
 
 	public boolean isWaitForScreenUnlock() {
-		return mPref.getBoolean("screen_on_unlock", true);
+		return getPreferences().getBoolean("screen_on_unlock", true);
 	}
 
 	public boolean isStartOnBoot() {
-		return mPref.getBoolean("start_on_boot", true);
+		return getPreferences().getBoolean("start_on_boot", true);
 	}
 
 	public String getSleepTime() {
-		return mPref.getString("sleep_time", Settings.DEFAULT_SLEEP);
+		return getPreferences().getString("sleep_time", Settings.DEFAULT_SLEEP);
 	}
 
 	public String getAwakeTime() {
-		return mPref.getString("awake_time", Settings.DEFAULT_AWAKE);
+		return getPreferences().getString("awake_time", Settings.DEFAULT_AWAKE);
 	}
 
 	public boolean isShowNotification() {
-		return mPref.getBoolean("show_notification", true);
+		return getPreferences().getBoolean("show_notification", true);
 	}
 
 	public boolean isUseApndroid() {
-		return mPref.getBoolean("apndroid", false);
+		return getPreferences().getBoolean("apndroid", false);
 	}
 
    public boolean isFirstRun() {
-      return mPref.getInt("first_run", 0) != FIRST_RUN_VERSION;
+      return getPreferences().getInt("first_run", 0) != FIRST_RUN_VERSION;
    }
 
    public void setFirstRun() {
-      mPref.edit().putInt("first_run", FIRST_RUN_VERSION).commit();     
+      getPreferences().edit().putInt("first_run", FIRST_RUN_VERSION).commit();     
    }
    
 	public void setNightmodeStart(String start) {
-		mPref.edit().putString("night_mode_start", start).commit();		
+		getPreferences().edit().putString("night_mode_start", start).commit();		
 	}
 
 	public void setNightmodeEnd(String end) {
-		mPref.edit().putString("night_mode_end", end).commit();		
+		getPreferences().edit().putString("night_mode_end", end).commit();		
 	}
 
 	public void setEnabled(boolean enabled) {
-		mPref.edit().putBoolean("enabled", enabled).commit();
+		getPreferences().edit().putBoolean("enabled", enabled).commit();
 	}
 
 	public boolean isDataOn() {
-		return mPref.getBoolean("data_state_on", true);
+		return getPreferences().getBoolean("data_state_on", true);
 	}
 
 	public void setDataStateOn(boolean on) {
-		mPref.edit().putBoolean("data_state_on", on).commit();
+		getPreferences().edit().putBoolean("data_state_on", on).commit();
 	}
 
 	public void setSyncOnData(boolean sync) {
-		mPref.edit().putBoolean("sync_on_data", sync).commit();
+		getPreferences().edit().putBoolean("sync_on_data", sync).commit();
 	}
 
 	public boolean isSyncOnData() {
-		return mPref.getBoolean("sync_on_data", false);
+		return getPreferences().getBoolean("sync_on_data", false);
 	}
 
 	public void setIsCharging(boolean isCharging) {
-		mPref.edit().putBoolean("state_charging", isCharging).commit();
+		getPreferences().edit().putBoolean("state_charging", isCharging).commit();
 	}
 	
 	public boolean isCharging() {
-		return mPref.getBoolean("state_charging", false);
+		return getPreferences().getBoolean("state_charging", false);
 	}
 	
 	public void setIsNightmode(boolean isNightmode) {
-		mPref.edit().putBoolean("state_nightmode", isNightmode).commit();
+		getPreferences().edit().putBoolean("state_nightmode", isNightmode).commit();
 	}
 	
 	public boolean isNightmode() {
-		return mPref.getBoolean("state_nightmode", false);
+		return getPreferences().getBoolean("state_nightmode", false);
 	}
 	
 	public void setLastWakeTime(long time) {
-		mPref.edit().putLong("last_wake_time", time).commit();
+		getPreferences().edit().putLong("last_wake_time", time).commit();
 	}
 	
 	public long getLastWakeTime() {
-		return mPref.getLong("last_wake_time", 0);
+		return getPreferences().getLong("last_wake_time", 0);
 	}
 	
    public void setIsTravelMode(boolean isTravelMode) {
-      mPref.edit().putBoolean("state_travelmode", isTravelMode).commit();
+      getPreferences().edit().putBoolean("state_travelmode", isTravelMode).commit();
    }
 	
    public boolean isTravelMode() {
-      return mPref.getBoolean("state_travelmode", false);
+      return getPreferences().getBoolean("state_travelmode", false);
    }
 
    public void setUseApnDroid(boolean use) {
-      mPref.edit().putBoolean("apndroid", use).commit();
+      getPreferences().edit().putBoolean("apndroid", use).commit();
    }
    
    public boolean isDisconnectOnScreenOff() {
-      return mPref.getBoolean("state_disconnect_on_screen_off", false);
+      return getPreferences().getBoolean("state_disconnect_on_screen_off", false);
    }
    
    public void setDisconnectOnScreenOff(boolean disable) {
-      mPref.edit().putBoolean("state_disconnect_on_screen_off", disable).commit();
+      getPreferences().edit().putBoolean("state_disconnect_on_screen_off", disable).commit();
    }
 
    public void setScreenOnOff(boolean screenOnOff)
    {
-       mPref.edit().putBoolean("screen_state_on", screenOnOff).commit();
+       getPreferences().edit().putBoolean("screen_state_on", screenOnOff).commit();
    }
 
    public boolean getScreenOnOff() {
-       return mPref.getBoolean("screen_state_on", true);
+       return getPreferences().getBoolean("screen_state_on", true);
    }
 
     public long getLastRun() {
-        return mPref.getLong("last_run", 0);
+        return getPreferences().getLong("last_run", 0);
     }
 
     public void setLastRun(long run)
     {
-        mPref.edit().putLong("last_run", run).commit();
+        getPreferences().edit().putLong("last_run", run).commit();
     }
 }

--- a/src/com/tobykurien/batteryfu/Settings.java
+++ b/src/com/tobykurien/batteryfu/Settings.java
@@ -4,7 +4,9 @@ import java.util.HashMap;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.preference.PreferenceManager;
+import android.util.Log;
 import android.widget.Toast;
 
 public class Settings {
@@ -17,52 +19,53 @@ public class Settings {
 	public static int AWAKE_PERIOD = 0;
 	public static int SLEEP_PERIOD = 0;
 	public static int FIRST_RUN_VERSION = 2;
+    public static final String PREFS_NAME = "com.tobykurien.BatteryFu.shared_prefs";
 
-	private SharedPreferences pref;
-	private static HashMap settingsCache = new HashMap();
-	
+	private SharedPreferences mPref;
+    private static Settings mInstance;
+
 	private Settings(SharedPreferences preferences) {
-		pref = preferences;
+		mPref = preferences;
 	}
-	
-	/**
-	 * Factory method to cache instances of settings class, since it's called a lot.
-	 * @param preferences
-	 * @return
-	 */
-	public static Settings getSettings(Context context) {
-	   /*
-		if (settingsCache.get(context) == null) {
-			SharedPreferences preferences = 	PreferenceManager.getDefaultSharedPreferences(context);
-			settingsCache.put(context, new Settings(preferences));
-		} 
-			
-		return (Settings) settingsCache.get(context); 
-		*/
 
-      SharedPreferences preferences =  PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
-      return new Settings(preferences);
+	public static synchronized Settings getSettings(Context context) {
+        if(mInstance == null)
+        {
+            SharedPreferences preferences;
+            Context ctx = context.getApplicationContext();
+            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB)
+            {
+                preferences = ctx.getSharedPreferences(PREFS_NAME, 0 | Context.MODE_MULTI_PROCESS);
+            }
+            else
+            {
+                preferences = ctx.getSharedPreferences(PREFS_NAME, 0);
+            }
+            mInstance = new Settings(preferences);
+        }
+
+      return mInstance;
 	}
 	
 	public boolean isDnsFix() {
-		return pref.getBoolean("dns_fix", false);		
+		return mPref.getBoolean("dns_fix", false);		
 	}
 
    public void setIsDnsFix(boolean dnsFix) {
-      pref.edit().putBoolean("dns_fix", dnsFix).commit();
+      mPref.edit().putBoolean("dns_fix", dnsFix).commit();
    }
 	
 	public boolean isEnabled() {
-		return pref.getBoolean("enabled", false);
+		return mPref.getBoolean("enabled", false);
 	}
 
    public boolean isForceSync() {
-      return pref.getBoolean("force_sync", true);
+      return mPref.getBoolean("force_sync", true);
    }
 	
    public boolean isNightmodeOnly() {
       if (!isNightmodeEnabled()) return false;
-      return pref.getBoolean("night_mode_only", false);
+      return mPref.getBoolean("night_mode_only", false);
    }
 
    public String getNightmodeStart() {
@@ -70,142 +73,160 @@ public class Settings {
 	}
 
 	public String getNightmodeStart(String defaultVal) {
-		return pref.getString("night_mode_start", defaultVal);
+		return mPref.getString("night_mode_start", defaultVal);
 	}	
 	
 	public String getNightmodeEnd() {
-		return pref.getString("night_mode_end", Settings.DEFAULT_NIGHT_MODE_END);
+		return mPref.getString("night_mode_end", Settings.DEFAULT_NIGHT_MODE_END);
 	}
 	
 	public boolean isDataWhileScreenOn() {
-		return pref.getBoolean("screen_on_data", false);
+		return mPref.getBoolean("screen_on_data", false);
 	}
 
 	public boolean isScreenOnKeepData() {
-      return pref.getBoolean("screen_keep_data", true);
+      return mPref.getBoolean("screen_keep_data", true);
    }
 
 	public boolean isMobileDataEnabled() {
-		return pref.getBoolean("mobile", false);
+		return mPref.getBoolean("mobile", false);
 	}
 
 	public boolean isDataWhileCharging() {
-		return pref.getBoolean("charger_on_data", false);
+		return mPref.getBoolean("charger_on_data", false);
 	}
 	
 	public boolean isNightmodeEnabled() {
-		return pref.getBoolean("night_mode_enabled", false);
+		return mPref.getBoolean("night_mode_enabled", false);
 	}
 
 	public boolean isWifiEnabled() {
-		return pref.getBoolean("wifi", true);
+		return mPref.getBoolean("wifi", true);
 	}
 
 	public String getScreenOffDelayTime() {
-		return pref.getString("screen_off_sleep_time", "30");
+		return mPref.getString("screen_off_sleep_time", "30");
 	}
 
 	public boolean isWaitForScreenUnlock() {
-		return pref.getBoolean("screen_on_unlock", true);
+		return mPref.getBoolean("screen_on_unlock", true);
 	}
 
 	public boolean isStartOnBoot() {
-		return pref.getBoolean("start_on_boot", true);
+		return mPref.getBoolean("start_on_boot", true);
 	}
 
 	public String getSleepTime() {
-		return pref.getString("sleep_time", Settings.DEFAULT_SLEEP);
+		return mPref.getString("sleep_time", Settings.DEFAULT_SLEEP);
 	}
 
 	public String getAwakeTime() {
-		return pref.getString("awake_time", Settings.DEFAULT_AWAKE);
+		return mPref.getString("awake_time", Settings.DEFAULT_AWAKE);
 	}
 
 	public boolean isShowNotification() {
-		return pref.getBoolean("show_notification", true);
+		return mPref.getBoolean("show_notification", true);
 	}
 
 	public boolean isUseApndroid() {
-		return pref.getBoolean("apndroid", false);
+		return mPref.getBoolean("apndroid", false);
 	}
 
    public boolean isFirstRun() {
-      return pref.getInt("first_run", 0) != FIRST_RUN_VERSION;
+      return mPref.getInt("first_run", 0) != FIRST_RUN_VERSION;
    }
 
    public void setFirstRun() {
-      pref.edit().putInt("first_run", FIRST_RUN_VERSION).commit();     
+      mPref.edit().putInt("first_run", FIRST_RUN_VERSION).commit();     
    }
    
 	public void setNightmodeStart(String start) {
-		pref.edit().putString("night_mode_start", start).commit();		
+		mPref.edit().putString("night_mode_start", start).commit();		
 	}
 
 	public void setNightmodeEnd(String end) {
-		pref.edit().putString("night_mode_end", end).commit();		
+		mPref.edit().putString("night_mode_end", end).commit();		
 	}
 
 	public void setEnabled(boolean enabled) {
-		pref.edit().putBoolean("enabled", enabled).commit();
+		mPref.edit().putBoolean("enabled", enabled).commit();
 	}
 
 	public boolean isDataOn() {
-		return pref.getBoolean("data_state_on", true);
+		return mPref.getBoolean("data_state_on", true);
 	}
 
 	public void setDataStateOn(boolean on) {
-		pref.edit().putBoolean("data_state_on", on).commit();
+		mPref.edit().putBoolean("data_state_on", on).commit();
 	}
 
 	public void setSyncOnData(boolean sync) {
-		pref.edit().putBoolean("sync_on_data", sync).commit();
+		mPref.edit().putBoolean("sync_on_data", sync).commit();
 	}
 
 	public boolean isSyncOnData() {
-		return pref.getBoolean("sync_on_data", false);
+		return mPref.getBoolean("sync_on_data", false);
 	}
 
 	public void setIsCharging(boolean isCharging) {
-		pref.edit().putBoolean("state_charging", isCharging).commit();
+		mPref.edit().putBoolean("state_charging", isCharging).commit();
 	}
 	
 	public boolean isCharging() {
-		return pref.getBoolean("state_charging", false);
+		return mPref.getBoolean("state_charging", false);
 	}
 	
 	public void setIsNightmode(boolean isNightmode) {
-		pref.edit().putBoolean("state_nightmode", isNightmode).commit();
+		mPref.edit().putBoolean("state_nightmode", isNightmode).commit();
 	}
 	
 	public boolean isNightmode() {
-		return pref.getBoolean("state_nightmode", false);
+		return mPref.getBoolean("state_nightmode", false);
 	}
 	
 	public void setLastWakeTime(long time) {
-		pref.edit().putLong("last_wake_time", time).commit();
+		mPref.edit().putLong("last_wake_time", time).commit();
 	}
 	
 	public long getLastWakeTime() {
-		return pref.getLong("last_wake_time", 0);
+		return mPref.getLong("last_wake_time", 0);
 	}
 	
    public void setIsTravelMode(boolean isTravelMode) {
-      pref.edit().putBoolean("state_travelmode", isTravelMode).commit();
+      mPref.edit().putBoolean("state_travelmode", isTravelMode).commit();
    }
 	
    public boolean isTravelMode() {
-      return pref.getBoolean("state_travelmode", false);
+      return mPref.getBoolean("state_travelmode", false);
    }
 
    public void setUseApnDroid(boolean use) {
-      pref.edit().putBoolean("apndroid", use).commit();
+      mPref.edit().putBoolean("apndroid", use).commit();
    }
    
    public boolean isDisconnectOnScreenOff() {
-      return pref.getBoolean("state_disconnect_on_screen_off", false);
+      return mPref.getBoolean("state_disconnect_on_screen_off", false);
    }
    
    public void setDisconnectOnScreenOff(boolean disable) {
-      pref.edit().putBoolean("state_disconnect_on_screen_off", disable).commit();
+      mPref.edit().putBoolean("state_disconnect_on_screen_off", disable).commit();
    }
+
+   public void setScreenOnOff(boolean screenOnOff)
+   {
+       mPref.edit().putBoolean("screen_state_on", screenOnOff).commit();
+   }
+
+   public boolean getScreenOnOff() {
+       return mPref.getBoolean("screen_state_on", true);
+   }
+
+    public long getLastRun() {
+        return mPref.getLong("last_run", 0);
+    }
+
+    public void setLastRun(long run)
+    {
+        mPref.edit().putLong("last_run", run).commit();
+    }
 }

--- a/src/com/tobykurien/batteryfu/compat/Api20.java
+++ b/src/com/tobykurien/batteryfu/compat/Api20.java
@@ -1,0 +1,22 @@
+package com.tobykurien.batteryfu.compat;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.os.PowerManager;
+
+
+/**
+ * Created by andy on 01/02/15.
+ */
+@TargetApi(Build.VERSION_CODES.KITKAT_WATCH)
+public class Api20 {
+    public static boolean isScreenOn(Context context)
+    {
+        PowerManager powerManager = (PowerManager) context.getSystemService(context.POWER_SERVICE);
+        if(powerManager.isInteractive())
+            return true;
+        else
+            return false;
+    }
+}

--- a/src/com/tobykurien/batteryfu/compat/Api7.java
+++ b/src/com/tobykurien/batteryfu/compat/Api7.java
@@ -1,0 +1,22 @@
+package com.tobykurien.batteryfu.compat;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.os.PowerManager;
+
+/**
+ * Created by andy on 01/02/15.
+ */
+@TargetApi(Build.VERSION_CODES.ECLAIR_MR1)
+
+public class Api7 {
+    public static boolean isScreenOn(Context context)
+    {
+        PowerManager powerManager = (PowerManager) context.getSystemService(context.POWER_SERVICE);
+        if(powerManager.isScreenOn())
+            return true;
+        else
+            return false;
+    }
+}

--- a/src/com/tobykurien/batteryfu/data_switcher/LollipopSwitcher.java
+++ b/src/com/tobykurien/batteryfu/data_switcher/LollipopSwitcher.java
@@ -78,7 +78,6 @@ public class LollipopSwitcher extends MobileDataSwitcher {
 
     @Override
     public int isToggleWorking(Context context) {
-        Log.d("BatteryFu", "isToggleWorking");
         if(init(context))
             return 0;
         else
@@ -86,7 +85,6 @@ public class LollipopSwitcher extends MobileDataSwitcher {
     }
 
     public boolean init(Context context) {
-        Log.d("BatteryFu", "init in LollipopSwitcher");
         try {
             // Perform su to get root priviledges
             Process p = Runtime.getRuntime().exec("su");

--- a/src/com/tobykurien/batteryfu/data_switcher/MobileDataSwitcher.java
+++ b/src/com/tobykurien/batteryfu/data_switcher/MobileDataSwitcher.java
@@ -20,13 +20,13 @@ public abstract class MobileDataSwitcher {
 	 * @return
 	 */
 	public static MobileDataSwitcher getSwitcher(Context context, Settings settings) {
-        if(Build.VERSION.SDK_INT >= 19) {
+        if(Build.VERSION.SDK_INT > 19) {
             if(lollipop.isToggleWorking(context) == 0) {
                 //Toast.makeText(context, "Using Lollipop switcher", Toast.LENGTH_LONG).show();
                 return lollipop;
             }
         }
-      if ((Build.VERSION.SDK_INT >= 14) && (Build.VERSION.SDK_INT < 19)) {
+      if ((Build.VERSION.SDK_INT >= 14) && (Build.VERSION.SDK_INT <= 19)) {
          if (ics.isToggleWorking(context) == 0) {
             //Toast.makeText(context, "Using ICS switcher", Toast.LENGTH_LONG).show();
             return ics;


### PR DESCRIPTION
On Kit Kat and Lollipop, mobile data is sometimes not disconnected after connection. This seems to happen more often on Lollipop and is quite annoying. 
The reason seems to be the behaviour of the PreferenceManager when working with Shared Preferences with multiple processes. A workaround is the re-reading of the preferences file on each preference update / read (which is a bit costly, though).

The acutal data toggling logic was also moved to its own (short-living) service, eliminating the need for a Thread object. 

The code works fine on my CM12 (Lollipop) Android build and is currently being tested on a CM11 (Kit Kat) build.